### PR TITLE
Web Client Tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,39 +1,245 @@
 version: 2
 
+attach: &attach
+  attach_workspace:
+    at: /home/circleci
+
+register_nypr_ads: &register_nypr_ads
+  run:
+    name: make global symlink
+    command: cd /home/circleci/nypr-ads && yarn link
+
+restore_node: &restore_node
+  restore_cache:
+    key: node-deps-{{ arch }}-{{ checksum "yarn.lock" }}
+
+install_node: &install_node
+  run:
+    name: node deps
+    command: |
+      if [ ! -d node_modules ]; then
+        yarn --pure-lockfile
+      fi
+
+save_node: &save_node
+  save_cache:
+    key: node-deps-{{ arch }}-{{ checksum "yarn.lock" }}
+    paths:
+      - node_modules
+
+restore_bower: &restore_bower
+  restore_cache:
+    key: bower-deps-{{ arch }}-{{ checksum "bower.json" }}
+
+install_bower: &install_bower
+  run:
+    name: bower deps
+    command: |
+      if [ ! -d bower_components ]; then
+        npx bower i
+      fi
+
+save_bower: &save_bower
+  save_cache:
+    key: bower-deps-{{ arch }}-{{ checksum "bower.json" }}
+    paths:
+      - bower_components
+
+build_modernizr: &build_modernizr
+  run:
+    name: Build modernizr
+    command: npx grunt modernizr:dist
+
+run_client_tests: &run_client_tests
+  run:
+    name: link and test
+    command: |
+      yarn link nypr-ads
+      npx ember test
+
+container_defaults: &defaults
+  docker:
+    - image: circleci/node:8.7-browsers
+      environment:
+        JOBS: 2
+
 jobs:
   install:
-    docker:
-      - image: circleci/node:8.7
-
+    <<: *defaults
+    working_directory: /home/circleci/nypr-ads
     steps:
       - checkout
 
-      - restore_cache:
-          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
-      - run:
-          name: Install node dependencies
-          command: |
-            if [ ! -d ./node_modules ]; then
-              yarn --pure-lockfile
-            fi
-      - save_cache:
-          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
+      - <<: *restore_node
+      - <<: *install_node
+      - <<: *save_node
+
+      - persist_to_workspace:
+          root: /home/circleci
           paths:
-            - ./node_modules
+            - nypr-ads
 
   test:
-    docker:
-      - image: circleci/node:8.7-browsers
-        environment:
-          JOBS: 2
+    <<: *defaults
+    working_directory: /home/circleci/nypr-ads
+    environment:
+      CIRCLE_TEST_REPORTS: test-results
 
     steps:
       - checkout
-      - restore_cache:
-          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
+      - <<: *restore_node
       - run:
-          name: Test
-          command: npx ember test
+          name: Runn addon tests
+          command: |
+            sudo yarn global add greenkeeper-lockfile@1
+            greenkeeper-lockfile-update
+            npx ember test
+            greenkeeper-lockfile-upload
+
+      - store_test_results:
+          path: test-results/
+
+  setup_test_clients:
+    docker:
+      - image: circleci/buildpack-deps:jessie
+    working_directory: /home/circleci
+    steps:
+      - run:
+          name: Keyscan Github
+          command: |
+            mkdir ~/.ssh
+            ssh-keyscan -H github.com >> ~/.ssh/known_hosts
+      - run:
+          name: clone clients
+          command: |
+            for client in wnyc wqxr new-sounds wnyc-studios; do
+              git clone git@github.com:nypublicradio/$client-web-client
+            done
+      - persist_to_workspace:
+          root: .
+          paths:
+            - wnyc-web-client
+            - wqxr-web-client
+            - new-sounds-web-client
+            - wnyc-studios-web-client
+
+  test_wnyc:
+    <<: *defaults
+    working_directory: /home/circleci/wnyc-web-client
+    environment:
+      CIRCLE_TEST_REPORTS: wnyc-test-results
+
+    steps:
+      - <<: *attach
+      - <<: *register_nypr_ads
+
+      - <<: *restore_node
+      - <<: *install_node
+      - <<: *save_node
+
+      - <<: *restore_bower
+      - <<: *install_bower
+      - <<: *save_bower
+
+      - <<: *build_modernizr
+
+      - <<: *run_client_tests
+
+      - store_test_results:
+          path: wnyc-test-results/
+
+  test_wqxr:
+    <<: *defaults
+    working_directory: /home/circleci/wqxr-web-client
+    environment:
+      CIRCLE_TEST_REPORTS: wqxr-test-results
+
+    steps:
+      - <<: *attach
+      - <<: *register_nypr_ads
+
+      - <<: *restore_node
+      - <<: *install_node
+      - <<: *save_node
+
+      - <<: *restore_bower
+      - <<: *install_bower
+      - <<: *save_bower
+
+      - <<: *build_modernizr
+
+      - <<: *run_client_tests
+
+      - store_test_results:
+          path: wqxr-test-results/
+
+  test_new_sounds:
+    <<: *defaults
+    working_directory: /home/circleci/new-sounds-web-client
+    environment:
+      CIRCLE_TEST_REPORTS: new-sounds-test-results
+
+    steps:
+      - <<: *attach
+      - <<: *register_nypr_ads
+
+      - <<: *restore_node
+      - <<: *install_node
+      - <<: *save_node
+
+      - <<: *run_client_tests
+
+      - store_test_results:
+          path: new-sounds-test-results/
+
+  test_wnyc_studios_ember:
+    <<: *defaults
+    parallelism: 4
+    working_directory: /home/circleci/wnyc-studios-web-client
+    environment:
+      CIRCLE_TEST_REPORTS: wnyc-studios-test-results
+
+    steps:
+      - <<: *attach
+      - <<: *register_nypr_ads
+
+      - <<: *restore_node
+      - <<: *install_node
+      - <<: *save_node
+
+      - <<: *build_modernizr
+
+      - run: |
+          cp .env.sample .env
+          npx ember exam --split=$CIRCLE_NODE_TOTAL --partition=$(($CIRCLE_NODE_INDEX + 1))
+
+      - store_test_results:
+          path: wnyc-studios-test-results/
+
+  test_wnyc_studios_cypress:
+    <<: *defaults
+    parallelism: 4
+    working_directory: /home/circleci/wnyc-studios-web-client
+    environment:
+      CIRCLE_TEST_REPORTS: wnyc-studios-test-results
+
+    steps:
+      - <<: *attach
+      - <<: *register_nypr_ads
+
+      - <<: *restore_node
+      - <<: *install_node
+      - <<: *save_node
+
+      - <<: *build_modernizr
+
+      - run: |
+          cp .env.sample .env
+          sudo apt-get install libgconf-2-4
+          yarn run cy:ci:test
+
+      - store_test_results:
+          path: wnyc-studios-test-results/
 
 workflows:
   version: 2
@@ -43,4 +249,31 @@ workflows:
       - test:
           requires:
             - install
+  test-all-clients:
+    jobs:
+      - install:
+          filters:
+            branches:
+              only: qa-build
+      - test:
+          requires:
+            - install
+      - setup_test_clients:
+          requires:
+            - install
+      - test_wnyc:
+          requires:
+            - setup_test_clients
+      - test_wqxr:
+          requires:
+            - setup_test_clients
+      - test_wnyc_studios_ember:
+          requires:
+            - setup_test_clients
+      - test_wnyc_studios_cypress:
+          requires:
+            - setup_test_clients
+      - test_new_sounds:
+          requires:
+            - setup_test_clients
 

--- a/circle.yml
+++ b/circle.yml
@@ -254,7 +254,7 @@ workflows:
       - install:
           filters:
             branches:
-              only: qa-build
+              only: master
       - test:
           requires:
             - install
@@ -276,4 +276,3 @@ workflows:
       - test_new_sounds:
           requires:
             - setup_test_clients
-


### PR DESCRIPTION
This circle file patch adds a serious test suite to the repo.

The plan is that on commits to master, Circle will clone the wnyc, wqxr, new sounds, and wnyc studios web clients and run their test suites against this version of nypr-ads.