### PR TITLE
Update the dfp-ad component to yield a tag and ad status values

### DIFF
--- a/addon/components/dfp-ad/tag.js
+++ b/addon/components/dfp-ad/tag.js
@@ -1,0 +1,6 @@
+import Component from '@ember/component';
+import layout from '../../templates/components/dfp-ad/tag';
+
+export default Component.extend({
+  layout
+});

--- a/addon/components/dfp-ad/tag.js
+++ b/addon/components/dfp-ad/tag.js
@@ -2,5 +2,6 @@ import Component from '@ember/component';
 import layout from '../../templates/components/dfp-ad/tag';
 
 export default Component.extend({
-  layout
+  layout,
+  tagName: '',
 });

--- a/addon/templates/components/dfp-ad.hbs
+++ b/addon/templates/components/dfp-ad.hbs
@@ -1,1 +1,13 @@
-<div id={{target}} class={{slotClassNames}}></div>
+{{#if (has-block)}}
+  {{yield (hash
+    tag=(component 'dfp-ad.tag'
+         target=target
+         slotClassNames=slotClassNames
+        )
+    isEmpty=adState.isEmpty
+    width=adState.width
+    height=adState.height
+  )}}
+{{else}}
+  <div id={{target}} class={{slotClassNames}}></div>
+{{/if}}

--- a/addon/templates/components/dfp-ad.hbs
+++ b/addon/templates/components/dfp-ad.hbs
@@ -4,9 +4,9 @@
          target=target
          slotClassNames=slotClassNames
         )
-    isEmpty=adState.isEmpty
-    width=adState.width
-    height=adState.height
+    isEmpty=this.isEmpty
+    width=this.width
+    height=this.height
   )}}
 {{else}}
   <div id={{target}} class={{slotClassNames}}></div>

--- a/addon/templates/components/dfp-ad/tag.hbs
+++ b/addon/templates/components/dfp-ad/tag.hbs
@@ -1,0 +1,1 @@
+<div id={{target}} class={{slotClassNames}}></div>

--- a/app/components/dfp-ad/tag.js
+++ b/app/components/dfp-ad/tag.js
@@ -1,0 +1,1 @@
+export { default } from 'nypr-ads/components/dfp-ad/tag';

--- a/tests/dummy/app/templates/docs/usage.md
+++ b/tests/dummy/app/templates/docs/usage.md
@@ -2,12 +2,25 @@
 
 ## The dfp-ad Component
 
-```javascript
+```hbs
   {{dfp-ad
     slotClassNames="l-constrained aligncenter leaderboard"
     slot="leaderboard/wqxr_leaderboard_demo"
     target="leaderboard_ad_home"
-    mapping=(array (array 0 (array 300 50)) (array 758 (array 728 90)) (array 1203 (array 970 415)))
+    mapping=(array 
+      (array 0
+        (array 300 50)
+      )
+      (array 758
+        (array 728 90)
+      )
+      (array 1203 
+        (array
+          (array 970 90)
+          (array 970 415)
+        )
+      )
+    )
     sizes=(array (array 970 415) (array 728 90) (array 300 50))
     slotRenderEndedAction=(action 'handleSlotRendered')
     clearOnEmptyRefresh=false
@@ -37,3 +50,26 @@ Things you might want to know when using this addon:
   * When googletag.pubads().refresh() is called to request a new ad and returns empty, the default GPT behavior is to keep the current ad. Set this to true if you want to `.clear()` the ad slot when empty. 
   * You might want to use this if you're using key/value targeting, and never want a targeted ad to stick around (due to lack of other ads) after you change the targeting.
 
+
+## Block Usage
+
+```hbs
+  {{#dfp-ad
+    slotClassNames="midpage-ad"
+    slot="leaderboard/gothamist_leaderboard"
+    sizes=(array (array 970 250) (array 970 90))
+  as |ad|}}
+    {{ad.tag}}
+    {{#unless ad.isEmpty}}
+      <span class="disclosure">Advertisement</span>
+      <span class="debug hidden">{{ad.width}}x{{ad.height}}</span>
+    {{/unless}}
+  {{/dfp-ad}}
+```
+
+For advanced usage, when provided a block the ad component yields the following:
+
+`tag` (component) - the actual element where the ad will be inserted
+`isEmpty` (boolean) - whether or not the ad is empty
+`width` (number) - width of the current ad, in pixels
+`height` (number) - height of the current ad, in pixels

--- a/tests/integration/components/dfp-ad-test.js
+++ b/tests/integration/components/dfp-ad-test.js
@@ -43,6 +43,49 @@ module('Integration | Component | dfp ad', function(hooks) {
     assert.equal(this.element.querySelector('.height').textContent, '0');
   });
 
+  test('it updates width and height', async function(assert) {
+    this.stub(googletag.cmd, 'push').callsFake( f => f());
+
+    let mockSlot = {
+      isEmpty: false,
+      size: [320, 50],
+      addService: this.mock().once(),
+    };
+
+    let mockEvent = {
+      isEmpty: false,
+      size: [320, 50],
+      slot: mockSlot,
+    };
+
+    let mockPubadsAPI = {
+      addEventListener(name, fn) {
+        if (name === 'slotRenderEnded') {
+          fn(mockEvent);
+        }
+      }
+    }
+
+    this.mock(googletag)
+      .expects('defineSlot')
+      .once()
+      .returns(mockSlot);
+
+    this.mock(googletag)
+      .expects('pubads')
+      .twice()
+      .returns(mockPubadsAPI);
+
+    await render(hbs`{{#dfp-ad target="foo" as |ad|}}
+      <span class="isEmpty">{{ad.isEmpty}}</span>
+      <span class="width">{{ad.width}}</span>
+      <span class="height">{{ad.height}}</span>
+    {{/dfp-ad}}`);
+
+    assert.equal(this.element.querySelector('.isEmpty').textContent, 'false');
+    assert.equal(this.element.querySelector('.width').textContent, '320');
+    assert.equal(this.element.querySelector('.height').textContent, '50');
+  });
 
   test('it sets an id automatically', async function(assert) {
     await render(hbs`{{dfp-ad slotClassNames='ad'}}`);

--- a/tests/integration/components/dfp-ad-test.js
+++ b/tests/integration/components/dfp-ad-test.js
@@ -31,14 +31,6 @@ module('Integration | Component | dfp ad', function(hooks) {
     assert.equal(findAll('#foo').length, 1);
   });
 
-  test('it yields an ad tag', async function(assert) {
-    await render(hbs`{{#dfp-ad target="foo" as |ad|}}
-      {{ad.tag}}
-    {{/dfp-ad}}`);
-
-    assert.equal(findAll('#foo').length, 1);
-  });
-
   test('it yields a default width and height', async function(assert) {
     await render(hbs`{{#dfp-ad target="foo" as |ad|}}
       <span class="isEmpty">{{ad.isEmpty}}</span>

--- a/tests/integration/components/dfp-ad-test.js
+++ b/tests/integration/components/dfp-ad-test.js
@@ -23,6 +23,35 @@ module('Integration | Component | dfp ad', function(hooks) {
     assert.equal(findAll('#foo').length, 1);
   });
 
+  test('it yields an ad tag', async function(assert) {
+    await render(hbs`{{#dfp-ad target="foo" as |ad|}}
+      {{ad.tag}}
+    {{/dfp-ad}}`);
+
+    assert.equal(findAll('#foo').length, 1);
+  });
+
+  test('it yields an ad tag', async function(assert) {
+    await render(hbs`{{#dfp-ad target="foo" as |ad|}}
+      {{ad.tag}}
+    {{/dfp-ad}}`);
+
+    assert.equal(findAll('#foo').length, 1);
+  });
+
+  test('it yields a default width and height', async function(assert) {
+    await render(hbs`{{#dfp-ad target="foo" as |ad|}}
+      <span class="isEmpty">{{ad.isEmpty}}</span>
+      <span class="width">{{ad.width}}</span>
+      <span class="height">{{ad.height}}</span>
+    {{/dfp-ad}}`);
+
+    assert.equal(this.element.querySelector('.isEmpty').textContent, 'true');
+    assert.equal(this.element.querySelector('.width').textContent, '0');
+    assert.equal(this.element.querySelector('.height').textContent, '0');
+  });
+
+
   test('it sets an id automatically', async function(assert) {
     await render(hbs`{{dfp-ad slotClassNames='ad'}}`);
     let div = this.element.querySelector('.ad');


### PR DESCRIPTION
[ENHANCEMENT] When the `dfp-ad` component is given a block, it yields its `tag` component, `isEmpty` status, and `width` and `height` in pixels, to make it easier to use for building more complex ad components.

One common use case for this is something like:
```hbs
{{#dfp-ad as |ad|}}
  {{#unless ad.isEmpty}}
    <span class="adlabel">ADVERTISEMENT</span>
  {{/unless}}
{{/dfp-ad}}
```

In the future I'd also like to add something like a set of `showLabel`,  `labelText`, and `labelClasses`, properties so you don't need a block for simpler cases, but using the block syntax makes it easier for us to directly use the ad label atom from the design system in our client.